### PR TITLE
feat(config): add probot/settings config extending actions.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,7 @@
+_extends: brianespinosa/settings:actions.yml
+
+repository:
+  name: next-build-cache
+  description: Composite action that sets up Next.js build cache for faster GitHub Actions build times
+  topics: github-actions,composite-action,cache,nextjs,nodejs
+  private: false

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Last Updated](https://img.shields.io/github/last-commit/brianespinosa/next-build-cache?label=Last%20Updated&cacheSeconds=120)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-Set up NextJS build cache for faster GitHub Actions build times
+Composite action that sets up Next.js build cache for faster GitHub Actions build times
 
 ```
 brianespinosa/next-build-cache@v3


### PR DESCRIPTION
## Summary

- Adds `.github/settings.yml` wiring this repo into the shared [brianespinosa/settings](https://github.com/brianespinosa/settings) config via `_extends: brianespinosa/settings:actions.yml`
- Sets repo-specific fields: `name`, `description`, `topics`, `private`
- Updates README description to match: "Composite action that sets up Next.js build cache..."

## Test plan

- [ ] Merge and confirm probot/settings app applies config to this repo